### PR TITLE
get width and height directly from video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
-# Label Studio Converter
+# (Our) Label Studio Converter (Fork)
+
+We add the ability to convert exported Label Studio video annotation JSON files to COCO format.
+
+Installation:
+- clone this repo
+- ```pip install -v -e .``` (in the repo directory)
+
+How to use:
+**Running from the command line:**
+
+```bash
+python label_studio_converter/main.py export -i 'exported_from_label_studio.json' -f COCO -c 'label-studio-config.xml' -o '/home/fabian/Desktop/output_std' (--video-file-path '/home/fabian/Downloads/00001_overlayed.mp4')
+
+```
+The --video-file-path argument is optional. If it is not provided, the video file path is assumed to be the same as the path of the video given in the JSON file.
+
+**Running from python:**
+```python
+from label_studio_converter import Converter
+
+c = Converter('examples/sentiment_analysis/config.xml')
+c.convert_video_to_coco(
+    "exported_from_label_studio.json",  # input file
+    "path/to/output/dir" # output directory
+    (video_file_path=args.video_file_path) # optional video file path
+)
+```
+
+
+---------------------
+-----------------
+# Original Repo README:
+
+
 
 [Website](https://labelstud.io/) • [Docs](https://labelstud.io/guide) • [Twitter](https://twitter.com/heartexlabs) • [Join Slack Community <img src="https://app.heartex.ai/docs/images/slack-mini.png" width="18px"/>](https://slack.labelstudio.heartex.com)
 

--- a/label_studio_converter/main.py
+++ b/label_studio_converter/main.py
@@ -76,6 +76,12 @@ def get_export_args(parser):
         default=True,
         help='Set this flag if your annotations are in one JSON file instead of multiple JSON files from directory',
     )
+    parser.add_argument(
+        '--video-file-path',
+        dest='video_file_path',
+        default=None,
+        help='Path to video file. If not specified, video file path will be taken from the provided json annotations file',
+    )
 
 
 def get_all_args():
@@ -136,12 +142,22 @@ def export(args):
     elif args.format == Format.CONLL2003:
         c.convert_to_conll2003(args.input, args.output, is_dir=not args.heartex_format)
     elif args.format == Format.COCO:
-        c.convert_to_coco(
-            args.input,
-            args.output,
-            output_image_dir=args.image_dir,
-            is_dir=not args.heartex_format,
-        )
+        # determine if it is in Label Studio image or video annotation format
+        # and use the appropriate converter
+        if c._data_keys[0] == "video":
+            c.convert_video_to_coco(
+                args.input,
+                args.output,
+                is_dir=not args.heartex_format,
+                video_file_path=args.video_file_path,
+            )
+        elif c._data_keys[0] == "image":
+            c.convert_to_coco(
+                args.input,
+                args.output,
+                output_image_dir=args.image_dir,
+                is_dir=not args.heartex_format,
+            )
     elif args.format == Format.VOC:
         c.convert_to_voc(
             args.input,


### PR DESCRIPTION
ich hab es mal so geändert, dass nicht jedes einzelne bild geladen wir, nur um seine Höhe und Breite zu finden. Stattdessen wird direkt aus dem Label Studio JSON das dort vermerkte video genommen und einfach hinter den video namen "frame_XYZ" drangehängt für die file_name Einträge im COCO JSON. Das video wird auch nur einmal geladen um Höhe, Breite und NUM_FRAMES zu laden.
TODO: Deine Ordnerstruktur des Synology Storages richtig einbinden, sodass das video aus dem Label Studio JSON gefunden wrden kann ohne es hochladen zu müssen. Das setzt natürlich vorraus, dass das converter skript auch auf der DGX ausgeführt wird. Ich dachte da an einen super basic docker container der einen webserver hostet welcher einfach die convert() funktion aufruft wenn man ihm ein JSON gibt. 